### PR TITLE
1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.4
+# 1.2.0
 
 -   Fixed bug where when the final result of a unit was 1 it would not be returned when using the short method:
 
@@ -19,3 +19,5 @@
     console.log(msConversion.relativeTime(137236834, true));
     // 1 day, 14 hours, 7 minutes, and 16 seconds
     ```
+
+-   Removed index.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'index' {
-    export function relativeTime(): string;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
     "name": "auro-ms-conversion",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "lockfileVersion": 1
 }


### PR DESCRIPTION
# 1.2.0

-   Fixed bug where when the final result of a unit was 1 it would not be returned when using the short method:

    **Before:**

    ```js
    console.log(msConversion.relativeTime(137236834));
    // 14h, 7m, and 16s
    console.log(msConversion.relativeTime(137236834, true));
    // 1 day, 14 hours, 7 minutes, and 16 seconds
    ```

    **After:**

    ```js
    console.log(msConversion.relativeTime(137236834));
    // 1d, 14h, 7m, and 16s
    console.log(msConversion.relativeTime(137236834, true));
    // 1 day, 14 hours, 7 minutes, and 16 seconds
    ```

-   Removed index.d.ts
